### PR TITLE
docs: add link to backend Chat API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Voice-first AI assistant for practicing spoken English.
 ## Status
 
 MVP in progress
+
+## Backend API
+
+Chat API documentation:
+👉 https://github.com/OlgaBieliaieva/ai-voice-english-tutor-backend/blob/main/docs/chat-api.md

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Summary
Add a reference to backend Chat API documentation:
- Linked backend Chat API docs from frontend README
- Clarified source of API contract

## Type of change
- [x] Chore / infrastructure
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Install dependencies: `npm install`
2. Run locally: `npm run dev`
3. Ensure CI build passes

## Related issues
Closes #7