### PR TITLE
feat: request and manage microphone access

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
+import MicrophoneButton from "./components/MicrophoneButton";
 import style from "./App.module.css";
 
 function App() {
   return (
     <div className={style.container}>
       <h1>AI Voice English Tutor</h1>
+      <MicrophoneButton />
     </div>
   );
 }

--- a/src/components/MicrophoneButton.jsx
+++ b/src/components/MicrophoneButton.jsx
@@ -1,0 +1,27 @@
+import { useMicrophone } from "../hooks/useMicrophone";
+
+export default function MicrophoneButton() {
+  const { status, requestPermission } = useMicrophone();
+
+  return (
+    <div>
+      <button onClick={requestPermission}>Enable microphone</button>
+
+      <p>
+        Status: <strong>{status}</strong>
+      </p>
+
+      {status === "denied" && (
+        <p style={{ color: "red" }}>
+          Microphone access denied. Please allow it in browser settings.
+        </p>
+      )}
+
+      {status === "unsupported" && (
+        <p style={{ color: "red" }}>
+          Your browser does not support microphone access.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useMicrophone.js
+++ b/src/hooks/useMicrophone.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+
+export function useMicrophone() {
+  const [status, setStatus] = useState("idle");
+  // idle | requesting | granted | denied | unsupported
+
+  const requestPermission = async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setStatus("unsupported");
+      return;
+    }
+
+    setStatus("requesting");
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream.getTracks().forEach((track) => track.stop());
+      setStatus("granted");
+    } catch (error) {
+      console.error("[MIC PERMISSION ERROR]", error);
+      setStatus("denied");
+    }
+  };
+
+  return {
+    status,
+    requestPermission,
+  };
+}


### PR DESCRIPTION
## Summary
Implemented microphone permission handling:
- Added browser microphone permission request
- Handled granted, denied, and unsupported states
- Displayed microphone status in UI
- Introduced reusable useMicrophone hook

## Type of change
- [ ] Chore / infrastructure
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Run frontend locally: `npm run dev`
2. Click “Enable microphone”
3. Allow or deny permission in browser prompt
4. Verify microphone status updates correctly in UI

## Related issues
Closes #10 