### PR TITLE
feat: implement speech-to-text input

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import MicrophoneButton from "./components/MicrophoneButton";
+import VoiceInput from "./components/VoiceInput";
 import style from "./App.module.css";
 
 function App() {
@@ -6,6 +7,7 @@ function App() {
     <div className={style.container}>
       <h1>AI Voice English Tutor</h1>
       <MicrophoneButton />
+      <VoiceInput />
     </div>
   );
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,5 +1,6 @@
 .container {
   display: flex;
+  flex-direction: column;
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;

--- a/src/components/VoiceInput.jsx
+++ b/src/components/VoiceInput.jsx
@@ -1,0 +1,34 @@
+import { useSpeechToText } from "../hooks/useSpeechToText";
+
+export default function VoiceInput() {
+  const {
+    isRecording,
+    transcript,
+    setTranscript,
+    startRecording,
+    stopRecording,
+    error,
+  } = useSpeechToText();
+
+  return (
+    <div>
+      <div>
+        {!isRecording ? (
+          <button onClick={startRecording}>🎙️ Start recording</button>
+        ) : (
+          <button onClick={stopRecording}>⏹ Stop recording</button>
+        )}
+      </div>
+
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      <textarea
+        value={transcript}
+        onChange={(e) => setTranscript(e.target.value)}
+        placeholder="Your speech will appear here..."
+        rows={4}
+        style={{ width: "100%", marginTop: "1rem" }}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useSpeechToText.js
+++ b/src/hooks/useSpeechToText.js
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+
+const SpeechRecognition =
+  window.SpeechRecognition || window.webkitSpeechRecognition;
+
+export function useSpeechToText() {
+  const recognitionRef = useRef(null);
+
+  const [isRecording, setIsRecording] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [error] = useState(
+    !SpeechRecognition
+      ? "Speech recognition is not supported in this browser"
+      : null
+  );
+
+  useEffect(() => {
+    if (!SpeechRecognition) return;
+
+    const recognition = new SpeechRecognition();
+    recognition.lang = "en-US";
+    recognition.interimResults = true;
+    recognition.continuous = true;
+
+    recognition.onresult = (event) => {
+      let text = "";
+
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        text += event.results[i][0].transcript;
+      }
+
+      setTranscript(text);
+    };
+
+    recognition.onerror = (event) => {
+      console.error("[STT ERROR]", event);
+      setIsRecording(false);
+    };
+
+    recognition.onend = () => {
+      setIsRecording(false);
+    };
+
+    recognitionRef.current = recognition;
+  }, []);
+
+  const startRecording = () => {
+    if (!recognitionRef.current) return;
+    setTranscript("");
+    recognitionRef.current.start();
+    setIsRecording(true);
+  };
+
+  const stopRecording = () => {
+    recognitionRef.current?.stop();
+    setIsRecording(false);
+  };
+
+  return {
+    isRecording,
+    transcript,
+    setTranscript,
+    startRecording,
+    stopRecording,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary
Added browser-native speech-to-text functionality:
- Implemented Web Speech API integration
- Added start/stop recording controls
- Displayed live transcription
- Allowed user to edit transcribed text
- Gracefully handled unsupported browsers and errors

## Type of change
- [ ] Chore / infrastructure
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Run frontend locally
2. Enable microphone permission
3. Click “Start recording”
4. Speak and observe live transcription
5. Stop recording and edit text manually

## Related issues
Closes #12