### PR TITLE
feat: add text-to-speech for AI responses

### DIFF
--- a/src/components/TTSPlayer.jsx
+++ b/src/components/TTSPlayer.jsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useTextToSpeech } from "../hooks/useTextToSpeech";
+
+export default function TTSPlayer({ text }) {
+  const { speak, stop, isSpeaking } = useTextToSpeech();
+
+  useEffect(() => {
+    if (text) {
+      speak(text);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text]);
+
+  if (!text) return null;
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      <button onClick={() => speak(text)} disabled={isSpeaking}>
+        ▶️ Play
+      </button>
+      <button onClick={stop} disabled={!isSpeaking}>
+        ⏹ Stop
+      </button>
+    </div>
+  );
+}

--- a/src/components/VoiceInput.jsx
+++ b/src/components/VoiceInput.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useSpeechToText } from "../hooks/useSpeechToText";
 import { sendChatMessage } from "../api/chatApi";
+import TTSPlayer from "./TTSPlayer";
 
 export default function VoiceInput() {
   const {
@@ -62,9 +63,12 @@ export default function VoiceInput() {
       </button>
 
       {reply && (
-        <div style={{ marginTop: "1rem" }}>
-          <strong>AI:</strong> {reply}
-        </div>
+        <>
+          <div style={{ marginTop: "1rem" }}>
+            <strong>AI:</strong> {reply}
+          </div>
+          <TTSPlayer text={reply} />
+        </>
       )}
     </div>
   );

--- a/src/hooks/useTextToSpeech.js
+++ b/src/hooks/useTextToSpeech.js
@@ -1,0 +1,38 @@
+import { useRef, useState } from "react";
+
+export function useTextToSpeech() {
+  const synthRef = useRef(window.speechSynthesis);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+
+  const speak = (text) => {
+    if (!window.speechSynthesis) {
+      console.error("TTS not supported in this browser");
+      return;
+    }
+
+    // stopping previous audio
+    if (synthRef.current.speaking) {
+      synthRef.current.cancel();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = "en-US";
+
+    utterance.onstart = () => setIsSpeaking(true);
+    utterance.onend = () => setIsSpeaking(false);
+    utterance.onerror = () => setIsSpeaking(false);
+
+    synthRef.current.speak(utterance);
+  };
+
+  const stop = () => {
+    synthRef.current.cancel();
+    setIsSpeaking(false);
+  };
+
+  return {
+    speak,
+    stop,
+    isSpeaking,
+  };
+}


### PR DESCRIPTION
## Summary
Implement text-to-speech for AI chat responses.

- Added useTextToSpeech hook using browser speechSynthesis
- TTSPlayer component added with Play/Stop controls
- AI responses automatically spoken when received
- Prevents overlapping audio playback

## Type of change
- [ ] Chore / infrastructure
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Start frontend: `npm run dev`
2. Send message to AI
3. Observe that AI response is spoken aloud
4. Try Play and Stop buttons
5. Ensure only one audio plays at a time

## Related issues
Closes #18 