### PR TITLE
feat: display grammar feedback separately

### DIFF
--- a/src/components/VoiceInput.jsx
+++ b/src/components/VoiceInput.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useSpeechToText } from "../hooks/useSpeechToText";
 import { sendChatMessage } from "../api/chatApi";
+import { parseLLMResponse } from "../utils/parseLLMResponse";
 import TTSPlayer from "./TTSPlayer";
 
 export default function VoiceInput() {
@@ -15,6 +16,7 @@ export default function VoiceInput() {
 
   const [loading, setLoading] = useState(false);
   const [reply, setReply] = useState(null);
+  const [feedback, setFeedback] = useState(null);
 
   const handleSend = async () => {
     if (!transcript.trim()) return;
@@ -24,7 +26,10 @@ export default function VoiceInput() {
 
       const response = await sendChatMessage(transcript);
 
-      setReply(response.reply);
+      const parsed = parseLLMResponse(response.reply);
+
+      setReply(parsed.reply);
+      setFeedback(parsed.feedback);
       setTranscript("");
     } catch (err) {
       console.error("[CHAT ERROR]", err);
@@ -63,12 +68,27 @@ export default function VoiceInput() {
       </button>
 
       {reply && (
-        <>
-          <div style={{ marginTop: "1rem" }}>
-            <strong>AI:</strong> {reply}
-          </div>
+        <div style={{ marginTop: "1rem" }}>
+          <strong>AI:</strong>
+          <p>{reply}</p>
           <TTSPlayer text={reply} />
-        </>
+        </div>
+      )}
+
+      {feedback && (
+        <div
+          style={{
+            marginTop: "1rem",
+            padding: "0.75rem",
+            borderLeft: "4px solid #4caf50",
+            backgroundColor: "#f6fff7",
+          }}
+        >
+          <strong>Grammar feedback:</strong>
+          <pre style={{ whiteSpace: "pre-wrap", marginTop: "0.5rem" }}>
+            {feedback}
+          </pre>
+        </div>
       )}
     </div>
   );

--- a/src/utils/parseLLMResponse.js
+++ b/src/utils/parseLLMResponse.js
@@ -1,0 +1,11 @@
+export function parseLLMResponse(text) {
+  if (!text) return { reply: "", feedback: "" };
+
+  const replyMatch = text.match(/REPLY:\s*([\s\S]*?)\s*FEEDBACK:/);
+  const feedbackMatch = text.match(/FEEDBACK:\s*([\s\S]*)/);
+
+  return {
+    reply: replyMatch ? replyMatch[1].trim() : "",
+    feedback: feedbackMatch ? feedbackMatch[1].trim() : "",
+  };
+}


### PR DESCRIPTION
## Summary
AI grammar feedback is now parsed and displayed separately from the main reply.

- LLM response is parsed into reply and feedback sections
- Grammar feedback rendered in a dedicated UI block
- Clear visual separation between conversation and corrections
- Improves learning experience without additional NLP complexity

## Type of change
- [ ] Chore / infrastructure
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

## How to test
1. Speak or type a sentence with grammar mistakes
2. Send message to backend
3. Verify AI reply appears as chat message
4. Verify grammar feedback appears in separate section
5. Ensure TTS reads only the AI reply

## Related issues
Closes #22